### PR TITLE
Add missing *_http_client_downloads columns in package_manager_data table

### DIFF
--- a/db/data_schema.sql
+++ b/db/data_schema.sql
@@ -23,9 +23,13 @@ CREATE TABLE `package_manager_data` (
   `python_downloads` int(11) unsigned DEFAULT NULL,
   `ruby_downloads` int(11) unsigned DEFAULT NULL,
   `java_downloads` int(11) unsigned DEFAULT NULL,
+  `open_source_library_data_collector_downloads` int(11) unsigned DEFAULT NULL,
   `python_http_client_downloads` int(11) unsigned DEFAULT NULL,
-  `csharp_http_client_downloads` INT(11) UNSIGNED DEFAULT NULL,
-  `ruby_http_client_downloads` INT(11) UNSIGNED DEFAULT NULL,
-  `node_http_client_downloads` INT(11) UNSIGNED DEFAULT NULL,
+  `csharp_http_client_downloads` int(11) unsigned DEFAULT NULL,
+  `ruby_http_client_downloads` int(11) unsigned DEFAULT NULL,
+  `node_http_client_downloads` int(11) unsigned DEFAULT NULL,
+  `php_http_client_downloads` int(11) unsigned DEFAULT NULL,
+  `java_http_client_downloads` int(11) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+

--- a/db/data_schema.sql
+++ b/db/data_schema.sql
@@ -24,5 +24,8 @@ CREATE TABLE `package_manager_data` (
   `ruby_downloads` int(11) unsigned DEFAULT NULL,
   `java_downloads` int(11) unsigned DEFAULT NULL,
   `python_http_client_downloads` int(11) unsigned DEFAULT NULL,
+  `csharp_http_client_downloads` INT(11) UNSIGNED DEFAULT NULL,
+  `ruby_http_client_downloads` INT(11) UNSIGNED DEFAULT NULL,
+  `node_http_client_downloads` INT(11) UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;


### PR DESCRIPTION
The following columns are missing on `data_schema.sql`:

  * csharp_http_client_downloads
  * ruby_http_client_downloads
  * node_http_client_downloads

