### PR TITLE
Add initial command-line interface script (Fix #7)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: python app.py
+worker: python cli.py update

--- a/app.py
+++ b/app.py
@@ -10,15 +10,24 @@ github = GitHub()
 pm = PackageManagers()
 sg = SendGrid()
 
-# Update the DB with the GitHub repo data
-for repo in config.github_repos:
-    github.update_library_data(config.github_user, repo)
 
-# Update the DB with Package Manager data
-pm.update_package_manager_data(config.package_manager_urls)
+def update(send_email=True):
+    # Update the DB with the GitHub repo data
+    for repo in config.github_repos:
+        github.update_library_data(config.github_user, repo)
 
-# Send an email update
-sg.send_email(config.to_email,
-              config.from_email,
-              config.email_subject,
-              config.email_body)
+    # Update the DB with Package Manager data
+    pm.update_package_manager_data(config.package_manager_urls)
+
+    if not send_email:
+        return
+
+    # Send an email update
+    sg.send_email(config.to_email,
+                  config.from_email,
+                  config.email_subject,
+                  config.email_body)
+
+
+if __name__ == "__main__":
+    update()

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,25 @@
+import sys
+
+from argparse import ArgumentParser
+
+from app import update
+
+
+def cli():
+    parser = ArgumentParser(description='Capture external data relating to GitHub hosted Open Source libraries')
+    command_parsers = parser.add_subparsers(title="command")
+    command_parsers.required = True
+
+    update_parser = command_parsers.add_parser('update',
+                                               help="update database with project's data")
+    update_parser.add_argument('--disable-email', dest='send_email', action='store_false')
+    update_parser.set_defaults(command_function=update)
+
+    args = vars(parser.parse_args())
+
+    command_function = args.pop('command_function')
+    return command_function(**args)
+
+
+if __name__ == "__main__":
+    sys.exit(int(cli() or 0))

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,12 @@
 import os
 import sys
+
 from setuptools import setup, find_packages
 
 long_description = 'Please see our GitHub README'
 if os.path.exists('README.txt'):
     long_description = open('README.txt').read()
+
 
 def getRequires():
     deps = ['github3.py',
@@ -27,6 +29,7 @@ def getRequires():
     elif (3, 3) <= sys.version_info < (3, 6):
         deps.append('pymysql')
     return deps
+
 
 base_url = 'https://github.com/sendgrid/'
 setup(
@@ -52,5 +55,8 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5'
-    ]
+    ],
+    entry_points={
+        'console_scripts': ['osscollect=cli:cli'],
+    },
 )


### PR DESCRIPTION
* Fixes #7 issue.
* Create a `cli.py` module with CLI argument parser in a way that allows future extensions (like an `export` sub-command).
* Replace `Procfile` worker configuration with CLI script (I can't test this change for now).
* Create an console entry point called `osscollect` (I accept suggestions for this name).
* Uses argparse instead of libraries like [`click`](https://github.com/pallets/click) to reduce the number of dependencies.