### PR TITLE
Bug/issue 62 fix illegal characters in tablename

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,6 +1,6 @@
 GITHUB_TOKEN=
 SENDGRID_API_KEY=
-MYSQL_DB=open-source-external-library-data
+MYSQL_DB=open_source_external_library_data
 MYSQL_HOST=127.0.0.1
 MYSQL_USERNAME=
 MYSQL_PASSWORD=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,8 +80,8 @@ cp .env_sample .env
 Update your settings in `.env`
 
 ```bash
-mysql -u USERNAME -p -e "CREATE DATABASE IF NOT EXISTS open-source-external-library-data";
-mysql -u USERNAME -p open-source-external-library-data < db/data_schema.sql
+mysql -u USERNAME -p -e "CREATE DATABASE IF NOT EXISTS open_source_external_library_data";
+mysql -u USERNAME -p open_source_external_library_data < db/data_schema.sql
 cp config_sample.yml config.yml
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ cp .env_sample .env
 Update your settings in `.env`
 
 ```bash
-mysql -u USERNAME -p -e "CREATE DATABASE IF NOT EXISTS open-source-library-data-collector";
-mysql -u USERNAME -p open-source-external-library-data < db/data_schema.sql
+mysql -u USERNAME -p -e "CREATE DATABASE IF NOT EXISTS open_source_external_library_data_collector";
 mysql -u USERNAME -p open_source_external_library_data < db/data_schema.sql
 cp config_sample.yml config.yml
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Update your settings in `.env`
 ```bash
 mysql -u USERNAME -p -e "CREATE DATABASE IF NOT EXISTS open-source-library-data-collector";
 mysql -u USERNAME -p open-source-external-library-data < db/data_schema.sql
+mysql -u USERNAME -p open_source_external_library_data < db/data_schema.sql
 cp config_sample.yml config.yml
 ```
 


### PR DESCRIPTION
Fixes #62 as part of hacktoberfest.

While replacing the characters, noticed that the table name unexpectedly changed in the first line of README.md, which is in contrast to the directions in the CONTRIBUTING.md. I believe that is a typo, so I fixed that issue as well.