### PR TITLE
Feature/issue 64 Add Github Issue and Pull Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+Welcome to Open-Source-Library-Data-Collector's GitHub repo! 👋🎉
+
+- Please **search for existing issues** in order to ensure we don't have duplicate bugs/feature requests.
+- Please be respectful and considerate of others when commenting on issues
+- Found a bug? Please fill out the sections below... thank you 👍
+
+### Issue Summary
+
+A summary of the issue and the browser/OS environment in which it occurs.
+
+Note: DO NOT include your credentials in ANY code examples, descriptions, or media you make public.
+
+### Steps to Reproduce
+
+1. This is the first step
+2. This is the second step, etc.
+
+Any other info e.g. Why do you consider this to be a bug? What did you expect to happen instead?
+
+### Technical details:
+
+* Python Version:
+* Browser/OS:
+* Database/Version:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!-- 
+Please explain WHAT you changed and WHY. 
+
+The title should be descriptive, for example:
+
+* *Fixed a typo in the apikeypermissions.md page*
+* *Added the maximum number of domain whitelabels you can create to domains.md*
+* *Fixing the number of days a batch id is valid in scheduling_parameters.md*
+
+If this PR fixes an issue, please reference the issue number as well.
+
+Fill out this form in the body:
+-->
+
+**Description of the change**:
+
+**Reason for the change**:
+
+**Link to original source**:
+
+### Checklist
+
+Make sure all of these items are complete, or else the PR will be ineligible for a code review.
+
+- [ ] Code passes all existing [tests](https://github.com/sendgrid/open-source-library-data-collector/tree/master/test)
+- [ ] Any new functionality added includes new unit tests in [`tests/test.py`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/test/test.py)
+- [ ] Create or update example code to show the new functionality in action.
+- [ ] All code, branch, and git naming and style conventions are followed (see [`CONTRIBUTING.md`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/CONTRIBUTING.md#style-guidelines--naming-conventions))
+- [ ] Feature branch has been rebased off of the latest `master` branch. ( see [`CONTRIBUTING.md`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/CONTRIBUTING.md#creating-a-pull-request) ).
+
+If you have questions, please send an email [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
+
+<!-- 
+Template based off of @ksigler7's Sendgrid docs PR template.
+https://raw.githubusercontent.com/sendgrid/docs/develop/.github/PULL_REQUEST_TEMPLATE
+@hydrosquall 
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Before you decide to create a new issue, please try the following:
 
 ### Please use our Bug Report Template
 
-In order to make the process easier, we've included a [sample bug report template](https://github.com/sendgrid/open-source-library-data-collector/.github/ISSUE_TEMPLATE) (borrowed from [Ghost](https://github.com/TryGhost/Ghost/)). The template uses [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown/) for formatting.
+In order to make the process easier, we've included a [sample bug report template](https://github.com/sendgrid/open-source-library-data-collector/.github/ISSUE_TEMPLATE.md) (borrowed from [Ghost](https://github.com/TryGhost/Ghost/)). The template uses [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown/) for formatting.
 
 <a name="improvements_to_the_codebase"></a>
 ## Improvements to the Codebase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Before you decide to create a new issue, please try the following:
 
 ### Please use our Bug Report Template
 
-In order to make the process easier, we've included a [sample bug report template](https://github.com/sendgrid/open-source-library-data-collector/.github/ISSUE_TEMPLATE.md) (borrowed from [Ghost](https://github.com/TryGhost/Ghost/)). The template uses [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown/) for formatting.
+In order to make the process easier, we've included a [sample bug report template](.github/ISSUE_TEMPLATE.md) (borrowed from [Ghost](https://github.com/TryGhost/Ghost/)). The template uses [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown/) for formatting.
 
 <a name="improvements_to_the_codebase"></a>
 ## Improvements to the Codebase


### PR DESCRIPTION
**Description of the change**:

- Fixes #64 
- Creates 2 new `.md` files with templates for making pull requests and filing issues
- Files are based on existing guidelines in `CONTRIBUTING.md`, and in existing Sendgrid projects (namely @ksigler7 's work in the [`/docs`](https://github.com/sendgrid/docs/blob/develop/.github/PULL_REQUEST_TEMPLATE) project ).
- Fixed broken link in `CONTRIBUTING.md`

**Reason for the change**:

These templates will make community contributions more consistent by embedding project guidelines directly into the Pull Request/Issue Filing process. See #64 for further discussion/context.

## Checklist

Make sure all of these items are complete, or else the PR will be ineligible for a code review.

- [x] Code passes all existing [tests](https://github.com/sendgrid/open-source-library-data-collector/tree/master/test)
- [x] Any new functionality added includes new unit tests in [`tests/test.py`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/test/test.py)
- [x] Create or update example code to show the new functionality in action.
- [x] All code, branch, and git naming and style conventions are followed (see [`CONTRIBUTING.md`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/CONTRIBUTING.md#style-guidelines--naming-conventions))
- [x] Feature branch has been rebased off of the latest `master` branch. ( see [`CONTRIBUTING.md`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/CONTRIBUTING.md#creating-a-pull-request) ).