### PR TITLE
Fixed error - int() on None type

### DIFF
--- a/package_managers.py
+++ b/package_managers.py
@@ -189,6 +189,21 @@ class PackageManagers(object):
             num_php_http_client_downloads,
             num_node_http_client_downloads
             ):
+        parms = [
+            num_total_csharp_downloads,
+            num_nodejs_monthly_downloads,
+            num_php_downloads,
+            num_python_downloads,
+            num_ruby_downloads,
+            num_python_http_client_downloads,
+            num_python_open_source_library_data_collector_downloads,
+            num_ruby_http_client_downloads,
+            num_csharp_http_client_downloads,
+            num_php_http_client_downloads,
+            num_node_http_client_downloads]
+
+        for parm in parms:
+            parm = None if parm is None else int(parm)
         """Update the DB with the package manager data
 
         :param num_total_csharp_downloads:   # of total downloads
@@ -207,11 +222,11 @@ class PackageManagers(object):
         """
         packagedata = PackageManagerData(
             date_updated=datetime.datetime.now(),
-            csharp_downloads=int(num_total_csharp_downloads),
-            nodejs_downloads=int(num_nodejs_monthly_downloads),
-            ruby_downloads=int(num_ruby_downloads),
-            csharp_http_client_downloads=int(num_csharp_http_client_downloads),
-            ruby_http_client_downloads=int(num_ruby_http_client_downloads),
-            node_http_client_downloads=int(num_node_http_client_downloads)
+            csharp_downloads=num_total_csharp_downloads,
+            nodejs_downloads=num_nodejs_monthly_downloads,
+            ruby_downloads=num_ruby_downloads,
+            csharp_http_client_downloads=num_csharp_http_client_downloads,
+            ruby_http_client_downloads=num_ruby_http_client_downloads,
+            node_http_client_downloads=num_node_http_client_downloads
             )
         return self.db.add_data(packagedata)


### PR DESCRIPTION
<!-- 
Please explain WHAT you changed and WHY. 

The title should be descriptive, for example:

* *Fixed a typo in the apikeypermissions.md page*
* *Added the maximum number of domain whitelabels you can create to domains.md*
* *Fixing the number of days a batch id is valid in scheduling_parameters.md*

If this PR fixes an issue, please reference the issue number as well.

Fill out this form in the body:
-->

**Description of the change**:
Checking for None first before running int() on download counts.  Wanted to be able to record null, 0, and >0 counts in the db.

**Reason for the change**:
Came across int() must be string or int not 'NoneType' error(s) when running with only one package_manager_urls in config.yml 

### Checklist

Make sure all of these items are complete, or else the PR will be ineligible for a code review.

- [x] Code passes all existing [tests](https://github.com/sendgrid/open-source-library-data-collector/tree/master/test)
- [x] Any new functionality added includes new unit tests in [`tests/test.py`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/test/test.py)
- [x] Create or update example code to show the new functionality in action.
- [x] All code, branch, and git naming and style conventions are followed (see [`CONTRIBUTING.md`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/CONTRIBUTING.md#style-guidelines--naming-conventions))
- [x] Feature branch has been rebased off of the latest `master` branch. ( see [`CONTRIBUTING.md`](https://github.com/sendgrid/open-source-library-data-collector/blob/master/CONTRIBUTING.md#creating-a-pull-request) ).


If you have questions, please send an email [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.

<!-- 
Template based off of @ksigler7's Sendgrid docs PR template.
https://raw.githubusercontent.com/sendgrid/docs/develop/.github/PULL_REQUEST_TEMPLATE
@hydrosquall 
-->
