### PR TITLE
Remove redundant license section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,6 @@ Quick links:
 - [Improvements to the Codebase](https://github.com/sendgrid/open-source-library-data-collector/blob/master/CONTRIBUTING.md#improvements_to_the_codebase)
 - [License](#license)
 
-# License
-[The MIT License (MIT)](LICENSE.txt)
-
 <a name="about"></a>
 # About
 
@@ -93,4 +90,5 @@ open-source-library-data-collector is maintained and funded by SendGrid, Inc. Th
 
 <a name="license"></a>
 # License
+
 [The MIT License (MIT)](LICENSE.txt)


### PR DESCRIPTION
Both PR #80 and #82 added a `# License` section to the README.
The latter also added a TOC and supersedes, so I've removed the older section.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- 
- 

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
